### PR TITLE
reverse char list, context manager added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/images
+Pipfile
+Pipfile.lock
+/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "venv/bin/python3"
-}

--- a/ascii.py
+++ b/ascii.py
@@ -1,6 +1,7 @@
 from PIL import Image, ImageDraw, ImageFont
-import math
 import argparse
+from helper import set_chars, getChar, arg_setup_string
+
 #
 # Developers:
 # Robert Hunnicutt:   https://github.com/RobHunn
@@ -9,93 +10,51 @@ import argparse
 #
 
 
-# grab command line arguments
+# Create command line argument parser.
 parser = argparse.ArgumentParser(
     description="Turn any photo into ascii art from the Command Line."
 )
-parser.add_argument(
-    "image", type=str,
-    default=None,
-    help="The image to convert to ascii art. Required."
-)
-parser.add_argument(
-    "--output",
-    type=str,
-    default='output',
-    help='The name of the file to save the png and text output. Eg - img1. Optional (default is "output")',
-)
-parser.add_argument(
-    "--charW",
-    type=int,
-    default=12,
-    help='The width of a single character Type=int default=12',
-)
-parser.add_argument(
-    "--charH",
-    type=int,
-    default=18,
-    help='The height of a single character Type=Int default=18',
-)
-parser.add_argument(
-    "--scale",
-    type=float,
-    default=.10,
-    help='The scale of image Type=float default=.10',
-)
-# convert parser.parse_args() SimpleNamespace to dictionary.
-# Remove keys with value of None.
-args = {k: v for k, v in vars(parser.parse_args()).items() if v != None}
-print(args)
-chars = "$@B%8&WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/\\|()1{}[]?-_+~<>i!lI;:,\"^`'. "[::-1]
+#  Add all parser arguments.
+#  This is kinda weird, just wanted to see if I could make this script
+#  less cluttered by moving parser args to helper.py and process here.
+[eval(w) for w in arg_setup_string.split("|")]
 
-charArray = list(chars)
-charLength = len(charArray)
-interval = charLength / 256
+# convert parser.parse_args() SimpleNamespace to dictionary for unpackability.
+args = dict(vars(parser.parse_args()))
+
+# Set charachters to use as pixels and reverse the order if reverse arg is true.
+set_chars(args)
 
 
-def getChar(inputInt):
-    return charArray[math.floor(inputInt * interval)]
-
-
-def ascii_art(charW, charH, scale, image, output, output_txt="output"):
-    if not image:
-        return
-    text_file = open(f"{output}.txt", "w")
-
+def ascii_art(charW, charH, scale, image, output):
+    """Function to convert image into ascii art. Photo and text output."""
     im = Image.open(image)
-    # You may have to chage this line to a font on your system too work this is my relative path
+
     fnt = ImageFont.truetype("arial.ttf", 15)
 
     width, height = im.size
     im = im.resize(
-        (
-            int(scale * width),
-            int(scale * height * (charW / charH)),
-        ),
-        Image.NEAREST,
+        (int(scale * width), int(scale * height * (charW / charH)),), Image.NEAREST,
     )
     width, height = im.size
     pix = im.load()
 
-    outputImage = Image.new(
-        "RGB", (charW * width, charH * height), color=(0, 0, 0)
-    )
+    outputImage = Image.new("RGB", (charW * width, charH * height), color=(0, 0, 0))
     d = ImageDraw.Draw(outputImage)
 
-    for i in range(height):
-        for j in range(width):
-            r, g, b = pix[j, i]
-            h = int(r / 3 + g / 3 + b / 3)
-            pix[j, i] = (h, h, h)
-            text_file.write(getChar(h))
-            d.text(
-                (j * charW, i * charH),
-                getChar(h),
-                font=fnt,
-                fill=(r, g, b),
-            )
+    with open(f"{output}.txt", "w") as text_file:
+        for i in range(height):
+            for j in range(width):
+                r, g, b = pix[j, i]
+                h = int((r + g + b) / 3)
+                # pix[j, i] = (h, h, h)  # what the heck does this do? nothing me-thinks.
+                char = getChar(h)
+                text_file.write(char)
+                d.text(
+                    (j * charW, i * charH), char, font=fnt, fill=(r, g, b),
+                )
 
-        text_file.write("\n")
+            text_file.write("\n")
 
     outputImage.save(f"{output}.png")
 

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,56 @@
+
+CHARS = list(
+    """ .'`^",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$"""
+)
+INTERVAL = len(CHARS) / 256
+
+
+def set_chars(args):
+    """Function to reverse CHARS if rev flag set."""
+    if args["rev"]:
+        CHARS.reverse()
+    del args["rev"]
+
+
+def getChar(val):
+    """Function to convert val 0-255 to one of available charachters."""
+    return CHARS[int(val * INTERVAL)]
+
+
+arg_setup_string = """
+parser.add_argument(
+    "image",
+    type=str,
+    # default=None,  # I think this is unneccesarry. Get same message with or without default when image is omitted.
+    help="The image to convert to ascii art. Required.",
+)|
+parser.add_argument(
+    "--output",
+    type=str,
+    default="output",
+    help='The name of the file to save the png and text output. Eg - img1. Optional (default is "output")',
+)|
+parser.add_argument(
+    "--charW",
+    type=int,
+    default=12,
+    help="The width of a single character Type=int default=12",
+)|
+parser.add_argument(
+    "--charH",
+    type=int,
+    default=18,
+    help="The height of a single character Type=Int default=18",
+)|
+parser.add_argument(
+    "--scale",
+    type=float,
+    default=0.10,
+    help="The scale of image Type=float default=.10",
+)|
+parser.add_argument(
+    "--rev",
+    type=bool,
+    default=False,
+    help="Reverse the order of charachter maping to color input.",
+)"""


### PR DESCRIPTION
### From best to more controversial changes:

Add --rev flag to reverse the character order. Now for images on a white background, you can get good results too. So pure white prints with space char with --rev True.

Put the open() call in a context manager (e.g. with open() as f:). Better as it makes sure to close the open file.

Removed use of math.floor (line 57) as I believe just calling int() will have the same effect in this case.
Removed .vscode and put in .gitignore.

Moved character functions to helper.py.

Minor syntax changes in ascii_art. My format-er (Black) changed some things, so we should pick one formater or code styling may flip flop.

moved parser.add_argument calls to a string in helper.py which gets eval() 'ed in a list comprehension in ascii.py. Kinda weird, I'm not sure this is something one would normally do.
I just wanted to see if could make ascii.py look cleaner with less code. Wadda ya think? Probably too weird, lol. There's probably a better way to accomplish the same.


